### PR TITLE
Automatically colour and (optionally) hide passed exams

### DIFF
--- a/npu.user.js
+++ b/npu.user.js
@@ -1246,7 +1246,7 @@ var npu = {
 				if ($(row).find("td[n=Attended]")[0].attributes["checked"].value == "false") {
 					$(row).addClass("npu_missed").attr("data-missed", "1");
 				} else {
-					if (npu.isPassingGrade($(row).find("td:nth-child(14)").html())) {
+					if (npu.isPassingGrade($(row).find("td:nth-child(13)").html())) {
 						$(row).addClass("npu_completed").attr("data-completed", "1");
 					} else {
 						$(row).addClass("npu_failed").attr("data-failed", "1");

--- a/npu.user.js
+++ b/npu.user.js
@@ -474,7 +474,7 @@ var npu = {
 				return $("#upFilter_cmbTerms, #upFilter_cmb_m_cmb, #cmbTermsNormal, #upFilter_cmbTerms_m_cmb, #cmb_cmb, #c_common_timetable_cmbTermsNormal, #cmbTerms_cmb").first();
 			};
 			var clickExecuteButton = function() {
-				if(["0303", "h_addsubjects", "0401", "h_exams", "0402", "h_signedexams", "0503", "h_transactionlist"].indexOf(npu.getPage()) != -1) {
+				if(["0303", "h_addsubjects", "0401", "h_exams", "0503", "h_transactionlist"].indexOf(npu.getPage()) != -1) {
 					return;
 				}
 				npu.runEval(function() {
@@ -1029,10 +1029,17 @@ var npu = {
 
 			// If the student has requested to expand all subrows, disable it.
 			// We are overriding this behaviour later on.
-			if (unsafeWindow.A2 && unsafeWindow.A2.AllSubrowExpanded == "True") {
+			// A2 can become even A3 and A4 and I don't know what else...
+			if (unsafeWindow.A1 && unsafeWindow.A1.AllSubrowExpanded == "True") {
+				unsafeWindow.A1.ShowAllSubrows();
+			} else if (unsafeWindow.A2 && unsafeWindow.A2.AllSubrowExpanded == "True") {
 				unsafeWindow.A2.ShowAllSubrows();
-			} else if (unsafeWindow.A3 && unsafeWindow.A3.AllSubrowExpanded == "True") { // Apparently, A2 sometimes becomes A3.
+			} else if (unsafeWindow.A3 && unsafeWindow.A3.AllSubrowExpanded == "True") {
 				unsafeWindow.A3.ShowAllSubrows();
+			} else if (unsafeWindow.A4 && unsafeWindow.A4.AllSubrowExpanded == "True") {
+				unsafeWindow.A4.ShowAllSubrows();
+			} else if (unsafeWindow.A5 && unsafeWindow.A5.AllSubrowExpanded == "True") {
+				unsafeWindow.A5.ShowAllSubrows();
 			}
 			$.examSubrowsExpanded = false;
 
@@ -1113,9 +1120,9 @@ var npu = {
 
 						npu.colourExams();
 						npu.hideSuccessfulExams();
-					}, 250);
+					}, 1000);
 				}
-			}, 100);
+			}, 250);
 		},
 
 		colourExams: function() {

--- a/npu.user.js
+++ b/npu.user.js
@@ -1147,16 +1147,22 @@ var npu = {
 
 		hideSuccessfulExams: function() {
 			if(npu.getUserData(null, null, "filterExams") == "1") {
+				var subjectsToHide = [];
 				var hiddenRowCount = 0;
 
 				$("#h_exams_gridExamList_bodytable tbody tr[hc=true]").each(function(idx, row) {
 					var lastMark = $("#h_exams_gridExamList_bodytable tbody tr.subrow#" + row.id.replace("tr__", "trs__")).first().find("table.subtable tbody tr:last td:nth-child(4)").html();
 
 					if (npu.isPassingGrade(lastMark)) {
+						++hiddenRowCount;
+
+						var subjectName = $(row).find("td:nth-child(2)").find("span").first().html();
+						if ($.inArray(subjectName, subjectsToHide) === -1) {
+							subjectsToHide[subjectsToHide.length] = subjectName
+						}
+
 						$(row).remove();
 						$("#h_exams_gridExamList_bodytable tbody tr.subrow#" + row.id.replace("tr__", "trs__")).first().remove();
-
-						++hiddenRowCount;
 					}
 				});
 
@@ -1166,6 +1172,14 @@ var npu = {
 						return pFirst + "-" + (pLast - hiddenRowCount) + "/" + (pCount - hiddenRowCount);
 					})
 				);
+
+				$.each(subjectsToHide, function(idx, subjectName) {
+					$("#upFilter_cmbSubjects").children("option").each(function() {
+						if (~$(this).html().indexOf(subjectName)) {
+							$(this).remove();
+						}
+					});
+				});
 			}
 		},
 

--- a/npu.user.js
+++ b/npu.user.js
@@ -1132,8 +1132,8 @@ var npu = {
 						});
 
 						if(npu.getUserData(null, null, "filterExams") == "1") {
-							successfulExams = npu.getSuccessfulExams();
-							npu.hideSuccessfulExams(successfulExams);
+							successfulExams = npu.getSuccessfulExamSubjects();
+							npu.removeExams(successfulExams);
 						}
 						
 						npu.initializeExamFiltering();
@@ -1240,7 +1240,7 @@ var npu = {
 			});
 		},
 
-		getSuccessfulExams: function() {
+		getSuccessfulExamSubjects: function() {
 			if(npu.getUserData(null, null, "filterExams") == "1") {
 				var subjectsToHide = [];
 
@@ -1259,11 +1259,11 @@ var npu = {
 			}
 		},
 		
-		hideSuccessfulExams: function(successfulExams) {
+		removeExams: function(subjects) {
 			if(npu.getUserData(null, null, "filterExams") == "1") {
 				$("#h_exams_gridExamList_bodytable tbody tr[hc=true]").each(function(idx, row) {
 					var subjectName = $(row).find("td:nth-child(2)").find("span").first().html();
-					if ($.inArray(subjectName, successfulExams) !== -1) {
+					if ($.inArray(subjectName, subjects) !== -1) {
 						$(row).remove();
 						$("#h_exams_gridExamList_bodytable tbody tr.subrow#" + row.id.replace("tr__", "trs__")).first().remove();
 					}
@@ -1319,9 +1319,9 @@ var npu = {
 
 					window.setTimeout(function() {
 						npu.colourSignedExams();
-					}, 250);
+					}, 1000);
 				}
-			}, 100);
+			}, 500);
 		},
 
 		colourSignedExams: function() {

--- a/npu.user.js
+++ b/npu.user.js
@@ -991,14 +991,7 @@ var npu = {
 	
 		/* Decide whether the given grade string constitutes passing the exam */
 		isPassingGrade: function(gradeStr) {
-			if (npu.getLanguage() == "hu") {
-				return gradeStr != "Elégtelen" && gradeStr != "Nem felelt meg" && gradeStr != "Nem jelent meg";
-			} else if (npu.getLanguage() == "en") {
-				return gradeStr != "Fail" && gradeStr != "Did not attend";
-			} else if (npu.getLanguage() == "de") {
-				// ???
-				return gradeStr != "Elégtelen" && gradeStr != "Nem felelt meg" && gradeStr != "Nem jelent meg";
-			}
+			return ["Elégtelen", "Nem felelt meg", "Nem jelent meg", "Fail", "Did not attend"].indexOf(gradeStr) == -1;
 		},
 
 		/* Enhance exam list style and functionality */
@@ -1053,7 +1046,7 @@ var npu = {
 				var filterEnabled = npu.getUserData(null, null, "filterExams");
 				var pager = $("#h_exams_gridExamList_gridmaindiv .grid_pagertable .grid_pagerpanel table tr");
 				if($("#npu_filter_exams").size() == 0) {
-					var filterCell = $('<td id="npu_filter_exams" style="padding-right: 30px; line-height: 17px"><input type="checkbox" id="npu_filter_field" style="vertical-align: middle" />&nbsp;&nbsp;<label for="npu_filter_field">Sikeres vizsgák elrejtése</label></td>');
+					var filterCell = $('<td id="npu_filter_exams" style="padding-right: 30px; line-height: 17px"><input type="checkbox" id="npu_filter_field" style="vertical-align: middle" />&nbsp;&nbsp;<label for="npu_filter_field">Teljesített tárgyak elrejtése</label></td>');
 					$("input", filterCell).change(function(e) {
 						npu.setUserData(null, null, "filterExams", $(this).get(0).checked);
 						npu.saveData();
@@ -1342,25 +1335,6 @@ var npu = {
 		getPage: function() {
 			var result = (/ctrl=([a-zA-Z0-9_]+)/g).exec(window.location.href);
 			return result ? result[1] : null;
-		},
-
-		getLanguage: function() {
-			// QUESTION: There should be a more reliable way to do this...
-			var studentData = $("table.top_menu_wrapper tbody tr td li#mb1_Sajatadatok").first().html();
-
-			var startsWith = function(str, sub) {
-				return str.slice(0, sub.length) == sub;
-			}
-
-			if (startsWith(studentData, "Saját adatok")) {
-				return "hu";
-			} else if (startsWith(studentData, "My data")) {
-				return "en";
-			} else if (startsWith(studentData, "Persönliche Daten")) {
-				return "de";
-			}
-
-			return "??";
 		},
 
 		/* Get the current AJAX grid instance */

--- a/npu.user.js
+++ b/npu.user.js
@@ -1127,6 +1127,10 @@ var npu = {
 
 		colourExams: function() {
 			$("#h_exams_gridExamList_bodytable tbody tr[hc=true]").each(function(idx, row) {
+				if ($(row).hasClass("gridrow_blue")) {
+					return;
+				}
+
 				var lastMark = $("#h_exams_gridExamList_bodytable tbody tr.subrow#" + row.id.replace("tr__", "trs__")).first().find("table.subtable tbody tr:last td:nth-child(4)").html();
 
 				if (npu.isPassingGrade(lastMark)) {


### PR DESCRIPTION
I've added a few presentational features to NPU in regards to exams (what's better to do than learning right now :beer: ).

Subjects from which you have a passing grade will now have their exams coloured green to easily distinguish them as you no longer NEED to do an exam. Subjects you have only received failing grades will have a red background.
To make exam registration an easier process, a new user option is also introduced: it is now possible to hide exams from subjects you have passed (these are the now green background ones). Selecting this option will also remove the subject from the "subject:" filter drop-down.

Subject grades are selected from the latest registered mark in accordance with usual University Rules. The same colouring scheme is applied to "my signed exams" page.

Tested to work with ELTE, BME and BCE Neptuns. I've tried my best to keep the coding style to yours. :smiley:
