### PR TITLE
Fix consistency issues of exam coloring and filtering feature

### DIFF
--- a/npu.user.js
+++ b/npu.user.js
@@ -1147,7 +1147,6 @@ var npu = {
 						row.removeClass("npu_completed npu_failed npu_missed");
 						var attended = $("td[n=Attended]", row)[0].attributes["checked"].value == "true";
 						var passed = npu.isPassingGrade($("td:nth-child(13)", row).text().trim());
-						console.log(attended);
 						row.addClass(attended ? (passed ? "npu_completed" : "npu_failed") : "npu_missed");
 					});
 				}


### PR DESCRIPTION
Entirely overriding the way Neptun lists and displays exams resulted in inconsistent behavior and random bugs in Firefox under certain circumstances (slow page load, changing terms too quickly). This PR does its best to provide as much of the new functionality as possible, while keeping the number of internal changes to a minimum, which results in more reliable and future proof behavior.
