### PR TITLE
Prioritise colouring a signed exam over grade indicator

### DIFF
--- a/npu.user.js
+++ b/npu.user.js
@@ -1058,15 +1058,19 @@ var npu = {
 							}
 						});
 						
-						if(markRows.size() > 0) {
-							lastMark = markRows.last();
-							var mark = $("td:nth-child(4)", lastMark).text().trim();
-							if(npu.isPassingGrade(mark)) {
-								row.addClass("npu_completed").attr("data-completed", "1");
-								row.add(subRow)[filterEnabled ? "addClass" : "removeClass"]("npu_hidden");
+						if (!row.hasClass("gridrow_blue")) {
+							if(markRows.size() > 0) {
+								lastMark = markRows.last();
+								var mark = $("td:nth-child(4)", lastMark).text().trim();
+								if(npu.isPassingGrade(mark)) {
+									row.addClass("npu_completed").attr("data-completed", "1");
+									row.add(subRow)[filterEnabled ? "addClass" : "removeClass"]("npu_hidden");
+								}
+								else {
+									row.addClass("npu_failed");
+								}
 							}
-							else {
-								row.addClass("npu_failed");
+						}
 							}
 						}
 					});

--- a/npu.user.js
+++ b/npu.user.js
@@ -1058,19 +1058,22 @@ var npu = {
 							}
 						});
 						
-						if (!row.hasClass("gridrow_blue")) {
-							if(markRows.size() > 0) {
-								lastMark = markRows.last();
-								var mark = $("td:nth-child(4)", lastMark).text().trim();
-								if(npu.isPassingGrade(mark)) {
-									row.addClass("npu_completed").attr("data-completed", "1");
-									row.add(subRow)[filterEnabled ? "addClass" : "removeClass"]("npu_hidden");
-								}
-								else {
-									row.addClass("npu_failed");
-								}
+						if(markRows.size() > 0) {
+							lastMark = markRows.last();
+							var mark = $("td:nth-child(4)", lastMark).text().trim();
+							var classToBeAdded = "";
+							
+							if(npu.isPassingGrade(mark)) {
+								classToBeAdded = "npu_completed";
+								row.attr("data-completed", "1");
+								row.add(subRow)[filterEnabled ? "addClass" : "removeClass"]("npu_hidden");
 							}
-						}
+							else {
+								classToBeAdded = "npu_failed";
+							}
+							
+							if (!row.hasClass("gridrow_blue") && classToBeAdded !== "") {
+								row.addClass(classToBeAdded);
 							}
 						}
 					});


### PR DESCRIPTION
As per mentioned in #3 , the rework of the code introduced a small bug: NPU would forcibly add a grade indicator over a to-be-attended exam resulting in weird colours.

This should fix that. Now if an exam is marked signed by Neptun itself, no colour scheme override takes place.
