### PR TITLE
Filter subject selector on exams page

### DIFF
--- a/npu.user.js
+++ b/npu.user.js
@@ -1053,20 +1053,6 @@ var npu = {
 				}
 			});
 			
-			var nupAddToArray = function(arr, element) {
-				if ($.inArray(element, arr) === -1) {
-					arr[arr.length] = element;
-				}
-			}
-			
-			var stringHasSubstringInArray = function(arr, stringToMatch) {
-				var resultArr = $.grep(arr, function(elem) {
-					return stringToMatch.indexOf(elem) !== -1;
-				});
-				
-				return resultArr.length !== 0;
-			}
-			
 			window.setInterval(function() {
 				var table = $("#h_exams_gridExamList_bodytable");
 				var filterEnabled = npu.getUserData(null, null, "filterExams");

--- a/npu.user.js
+++ b/npu.user.js
@@ -1100,7 +1100,9 @@ var npu = {
 							$(this).removeClass("npu_hidden npu_completed npu_failed npu_subscribed npu_found");
 							var subjectCode = npu.parseSubjectCode($(this).text().trim());
 							var classToBeAdded = $.examSubjectFilterCache[subjectCode];
+							var filterEnabled = npu.getUserData(null, null, "filterExams");
 							subjectCode && $(this).addClass(classToBeAdded || "npu_hidden");
+							filterEnabled && classToBeAdded === "npu_completed" && $(this).addClass("npu_hidden");
 						});
 					}
 				}


### PR DESCRIPTION
Original idea and implementation by @whisperity: #7 
Related discussion: #5 

Fixes and enhancements:

* Remove `$.examSubjectFilterValid`, use `$.examSubjectFilterCache === null` to signal an invalid or nonexistent filter cache.
* Extract subject code parsing code from courses page to `npu.parseSubjectCode` and reuse it to parse subject code out of the subject selector on the exams page, instead of matching for substrings. This parsing code has already been battle-tested and properly handles even weird subject codes with `(`s and `)`s in them.
* Simplify logic for determining the class to add, and the logic that adds classes to `<option>`s.
* Remove cache invalidation when "completed exam filtering" is toggled, as my tests revealed that we don't need it.
* Adjust logic in `npu.initExamAutoList` to work with the updated code in `fixExamList`.