### PR TITLE
Include Teacher page for SZTE URL

### DIFF
--- a/npu.user.js
+++ b/npu.user.js
@@ -5,6 +5,7 @@
 // @version        1.52.8
 // @downloadURL    https://github.com/solymosi/npu/raw/master/npu.user.js
 // @include        https://*neptun*/*hallgato*/*
+// @include        https://*neptun*/*oktato*/*
 // @include        https://*hallgato*.*neptun*/*
 // @include        https://*oktato*.*neptun*/*
 // @include        https://netw*.nnet.sze.hu/hallgato/*


### PR DESCRIPTION
For SZTE teacher version of Neptun runs at:
https://*.neptun.u-szeged.hu/oktato/main.aspx

Added new include expr for this.