### PR TITLE
Closing modals when clicking outside them

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ A Neptun fejléce alapesetben a képernyő harmadát elfoglalja, ami kis képern
 
 Eleged van abból, hogy minden egyes alkalommal be kell állítanod, hogy 500 elemet akarsz látni egy oldalon a 20 helyett? A Neptun PowerUp! automatikusan 500 elemet jelenít meg minden listában, és eltünteti az oldalméret-választó menüt.
 
+#### Felugró ablakok könnyebb bezárása
+
+A felugró ablakok bezárásához most már nem kell eltalálni a kicsi X-et a sarokban, az ablakon kívülre kattintással is be lehet zárni.
+
 ## Újdonságok
 
 #### 2022. december 9.

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,7 @@ const modules = [
   require("./modules/hideSurveyPopup"),
   require("./modules/infiniteSession"),
   require("./modules/loadingIndicator"),
+  require("./modules/modalClose"),
 
   // Timetable page
   require("./modules/timetableFixes"),

--- a/src/modules/modalClose.js
+++ b/src/modules/modalClose.js
@@ -3,19 +3,17 @@ const utils = require("../utils");
 function addEvent() {
   window.addEventListener("click", event => {
     // If the click is outside an open modal
-    if (event.target.matches(".ui-widget-overlay")) {
-      const closeButtons = document.querySelectorAll(".ui-dialog-titlebar-close");
-      const lastCloseButton = closeButtons[closeButtons.length - 1];
-      if (lastCloseButton) {
-        //Close the topmost modal
-        lastCloseButton.click();
+    if (event.target.classList.contains("ui-widget-overlay")) {
+      const dialogs = document.querySelectorAll(".ui-dialog");
+      const topmostDialog = dialogs[dialogs.length - 1];
+      const closeButton = topmostDialog.querySelector(".ui-dialog-titlebar-close");
+      if (closeButton) {
+        closeButton.click();
       }
     }
   });
 }
 module.exports = {
   shouldActivate: () => utils.isLoggedIn(),
-  initialize: () => {
-    addEvent();
-  },
+  initialize: addEvent,
 };

--- a/src/modules/modalClose.js
+++ b/src/modules/modalClose.js
@@ -1,0 +1,21 @@
+const utils = require("../utils");
+
+function addEvent() {
+  window.addEventListener('click', () => {
+    // If the click is outside an open modal
+    if(event.target.matches('.ui-widget-overlay')) {
+      const closeButtons = document.querySelectorAll('.ui-dialog-titlebar-close');
+      const lastCloseButton = closeButtons[closeButtons.length-1];
+      if(lastCloseButton) {
+        //Close the topmost modal
+        lastCloseButton.click();
+      }
+    }
+  })
+}
+module.exports = {
+  shouldActivate: () => utils.isLoggedIn(),
+  initialize: () => {
+    addEvent();
+  },
+};

--- a/src/modules/modalClose.js
+++ b/src/modules/modalClose.js
@@ -1,17 +1,17 @@
 const utils = require("../utils");
 
 function addEvent() {
-  window.addEventListener('click', () => {
+  window.addEventListener("click", event => {
     // If the click is outside an open modal
-    if(event.target.matches('.ui-widget-overlay')) {
-      const closeButtons = document.querySelectorAll('.ui-dialog-titlebar-close');
-      const lastCloseButton = closeButtons[closeButtons.length-1];
-      if(lastCloseButton) {
+    if (event.target.matches(".ui-widget-overlay")) {
+      const closeButtons = document.querySelectorAll(".ui-dialog-titlebar-close");
+      const lastCloseButton = closeButtons[closeButtons.length - 1];
+      if (lastCloseButton) {
         //Close the topmost modal
         lastCloseButton.click();
       }
     }
-  })
+  });
 }
 module.exports = {
   shouldActivate: () => utils.isLoggedIn(),


### PR DESCRIPTION
This is a minor feature. It closes the topmost popup when the user clicks outside of it.

This is my first contribution here, so please check if I did everything right! I used DOM methods instead of jQuery, I don't know if that's a problem.

(This is my second pull request on this feature, I screwed up the first one)